### PR TITLE
Avoid Bundler deprecation warning by using 'bundle config set path'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,23 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Try to pull Docker test image
+    - name: Check for Docker file changes
+      uses: dorny/paths-filter@v3
+      id: docker-changes
+      with:
+        filters: |
+          docker:
+            - 'Dockerfile'
+            - 'docker-compose.yml'
+
+    - name: Pull or build Docker test image
       run: |
-        docker compose pull
+        if [ "${{ steps.docker-changes.outputs.docker }}" = "true" ]; then
+          echo "Dockerfile changed — building image locally"
+          docker compose build
+        else
+          docker compose pull
+        fi
 
     - name: Make shellspec executable
       run: chmod +x ./shellspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,24 +31,24 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ruby-install once (cached layer)
-RUN curl -fsSL https://github.com/postmodern/ruby-install/releases/download/v0.9.3/ruby-install-0.9.3.tar.gz | tar -xzf - \
-    && cd ruby-install-0.9.3 \
+RUN curl -fsSL https://github.com/postmodern/ruby-install/releases/download/v0.10.1/ruby-install-0.10.1.tar.gz | tar -xzf - \
+    && cd ruby-install-0.10.1 \
     && make install \
     && cd .. \
-    && rm -rf ruby-install-0.9.3
+    && rm -rf ruby-install-0.10.1
 
-# Stage for Ruby 3.2.4 compilation
-FROM base AS ruby-3-2-4
+# Stage for Ruby 4.0.1 compilation
+FROM base AS ruby-4-0-1
 
 RUN mkdir -p /opt/rubies && \
     MAKE_OPTS="-j$(nproc)" \
     ruby-install \
-        --install-dir /opt/rubies/ruby-3.2.4 \
+        --install-dir /opt/rubies/ruby-4.0.1 \
         --jobs $(nproc) \
         --cleanup \
-        ruby 3.2.4 \
+        ruby 4.0.1 \
         -- --with-jemalloc \
-    && /opt/rubies/ruby-3.2.4/bin/gem install bundler --no-document
+    && /opt/rubies/ruby-4.0.1/bin/gem install bundler --no-document
 
 # Stage for Ruby 3.4.5 compilation  
 FROM base AS ruby-3-4-5
@@ -73,7 +73,7 @@ RUN git clone https://github.com/shellspec/shellspec.git /tmp/shellspec \
     && rm -rf /tmp/shellspec
 
 # Copy compiled Ruby installations from parallel stages
-COPY --from=ruby-3-2-4 /opt/rubies/ruby-3.2.4 /opt/rubies/ruby-3.2.4
+COPY --from=ruby-4-0-1 /opt/rubies/ruby-4.0.1 /opt/rubies/ruby-4.0.1
 COPY --from=ruby-3-4-5 /opt/rubies/ruby-3.4.5 /opt/rubies/ruby-3.4.5
 
 # Create test user (non-root for realistic testing)

--- a/crates/rb-core/src/bundler/mod.rs
+++ b/crates/rb-core/src/bundler/mod.rs
@@ -131,7 +131,7 @@ impl BundlerRuntime {
         );
 
         let status = Command::new("bundle")
-            .args(["config", "path", "--local"])
+            .args(["config", "set", "path", "--local"])
             .arg(self.vendor_dir().to_string_lossy().as_ref())
             .current_dir(&self.root)
             .status_with_context(butler_runtime);

--- a/spec/behaviour/bash_completion_spec.sh
+++ b/spec/behaviour/bash_completion_spec.sh
@@ -102,8 +102,8 @@ Describe "Ruby Butler Bash Completion"
       It "provides only version numbers without CRuby prefix"
         When run rb __bash_complete "rb -r " 7 --rubies-dir "$RUBIES_DIR"
         The status should equal 0
+        The lines of output should not include "CRuby-4.0.1"
         The lines of output should not include "CRuby-3.4.5"
-        The lines of output should not include "CRuby-3.2.4"
       End
     End
 
@@ -136,7 +136,7 @@ Describe "Ruby Butler Bash Completion"
         mkdir -p "$PROJECT_DIR"
         cat > "$PROJECT_DIR/rbproject.toml" << 'EOF'
 [project]
-ruby = "3.4.5"
+ruby = "4.0.1"
 
 [scripts]
 test = "bundle exec rspec"

--- a/spec/commands/completion/context_aware_spec.sh
+++ b/spec/commands/completion/context_aware_spec.sh
@@ -156,11 +156,11 @@ Describe "Ruby Butler Context-Aware Completion"
   Describe "Dockerfile rubies path testing"
     Context "non-standard rubies location"
       It "completes rubies from /opt/rubies when explicitly specified"
-        # Test with Docker-style path (Docker has 3.2.4 and 3.4.5)
+        # Test with Docker-style path (Docker has 3.4.5 and 4.0.1)
         When run rb __bash_complete "rb -r " 7 --rubies-dir "/opt/rubies"
         The status should equal 0
+        The output should include "4.0.1"
         The output should include "3.4.5"
-        The output should include "3.2.4"
       End
     End
   End

--- a/spec/commands/sync_spec.sh
+++ b/spec/commands/sync_spec.sh
@@ -17,6 +17,13 @@ Describe 'rb sync command'
       The output should include "Environment Successfully Synchronized"
       The output should include "Bundle complete!"
     End
+
+    It 'does not emit bundler deprecation warnings'
+      When run rb -R "$RUBIES_DIR" sync
+      The status should be success
+      The output should include "Environment Successfully Synchronized"
+      The stderr should not include "[DEPRECATED]"
+    End
   End
 
   Context 'when running sync in non-bundler project'

--- a/spec/support/helpers.sh
+++ b/spec/support/helpers.sh
@@ -2,14 +2,14 @@
 # ShellSpec helper functions for Ruby Butler
 
 # Ruby versions available in Docker environment
-LATEST_RUBY="3.4.5"
-OLDER_RUBY="3.2.4"
+LATEST_RUBY="4.0.1"
+OLDER_RUBY="3.4.5"
 RUBIES_DIR="/opt/rubies"
 
 # Set RB_RUBIES_DIR for all tests so they use Docker Ruby installations
 export RB_RUBIES_DIR="$RUBIES_DIR"
 
-# Get Ruby ABI version from full version (e.g., "3.4.5" -> "3.4.0")
+# Get Ruby ABI version from full version (e.g., "4.0.1" -> "4.0.0")
 get_ruby_abi_version() {
     local version="$1"
     echo "$version" | sed -E 's/^([0-9]+\.[0-9]+).*/\1.0/'


### PR DESCRIPTION
This should fix the problem where `rb` causes Bundler to emit deprecation warnings, due to `bundle config KEY VALUE` being deprecated in favor of `bundle config set KEY VALUE`.

A screenshot of what prompted this PR:

<img width="1920" height="1024" alt="image" src="https://github.com/user-attachments/assets/aef30712-f99e-49d5-9e09-d391b89c678e" />
